### PR TITLE
[hotfix] fix docker-compose command

### DIFF
--- a/java/greeter/README.md
+++ b/java/greeter/README.md
@@ -46,7 +46,7 @@ take a few minutes as it also needs to build the function's Java project.
 Afterward the build completes, start running all the services:
 
 ```
-$ docker-compose run
+$ docker-compose up
 ```
 
 ## Play around!


### PR DESCRIPTION
`docker-compose run` is for running services and requires additional arguments. I assume `docker-compose up` was meant.