### PR TITLE
[FLINK-22185] Add k8s example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+target/
+*.iml
+.idea/
+venv/*
+__pycahe__/*
+.DS_Store

--- a/deployments/k8s/00-namespace/namespace.yaml
+++ b/deployments/k8s/00-namespace/namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: statefun
+

--- a/deployments/k8s/01-minio/minio.yaml
+++ b/deployments/k8s/01-minio/minio.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: statefun
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: statefun
+      component: minio
+  template:
+    metadata:
+      labels:
+        app: statefun
+        component: minio 
+      namespace: statefun
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio
+          command: ["minio"]
+          args: ["server", "/data"]
+          ports:
+            - containerPort: 9000
+              name: endpoint
+          livenessProbe:
+            tcpSocket:
+              port: 9000
+            initialDelaySeconds: 30
+            periodSeconds: 60
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio 
+  namespace: statefun
+spec:
+  type: ClusterIP
+  ports:
+    - name: endpoint
+      port: 9000
+  selector:
+    app: statefun
+    component: minio
+

--- a/deployments/k8s/02-kafka/kafka.yaml
+++ b/deployments/k8s/02-kafka/kafka.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: zookeeper-service
+  name: zookeeper-service
+  namespace: statefun 
+spec:
+  type: NodePort
+  ports:
+  - name: zookeeper-port
+    port: 2181
+    targetPort: 2181
+  selector:
+    app: zookeeper
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: zookeeper
+  name: zookeeper
+  namespace: statefun
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zookeeper
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+    spec:
+      containers:
+      - image: library/zookeeper:3.4.13
+        imagePullPolicy: IfNotPresent
+        name: zookeeper
+        ports:
+        - containerPort: 2181
+        env:
+        - name: ZOO_MY_ID
+          value: "1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  namespace: statefun 
+  labels:
+    app: kafka
+spec:
+  ports:
+  - port: 9092
+    name: plaintext
+  - port: 9999
+    name: jmx
+  clusterIP: None
+  selector:
+    app: kafka
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+  namespace: statefun
+spec:
+  selector:
+    matchLabels:
+      app: kafka
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+      - name: kafka
+        image: wurstmeister/kafka:2.11-2.0.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9092
+          name: plaintext
+        - containerPort: 9999
+          name: jmx
+        env:
+          - name: KAFKA_BROKER_ID
+            value: "1"
+          - name: KAFKA_ADVERTISED_HOST_NAME
+            value: "kafka.statefun.svc.cluster.local"
+          - name: KAFKA_ADVERTISED_PORT
+            value: "9092"
+          - name: KAFKA_ZOOKEEPER_CONNECT
+            value: "zookeeper-service:2181"
+          - name: KAFKA_LISTENERS
+            value: "PLAINTEXT://:9092"
+          - name: KAFKA_JMX_OPTS
+            value: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Djava.rmi.server.hostname=127.0.0.1"
+          - name: JMX_PORT
+            value: "9999"
+          - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE 
+            value: "true"
+          - name:  KAFKA_LOG_RETENTION_MS
+            value: "600000"
+          - name: KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS
+            value: "60000"
+          - name: KAFKA_TRANSACTION_MAX_TIMEOUT_MS
+            value: "3600000"

--- a/deployments/k8s/03-functions/Dockerfile
+++ b/deployments/k8s/03-functions/Dockerfile
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.9-slim-buster
+
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY requirements.txt /app
+RUN pip install -r requirements.txt
+
+COPY functions.py /app
+
+EXPOSE 8000
+
+CMD ["python3", "/app/functions.py"]
+

--- a/deployments/k8s/03-functions/Makefile
+++ b/deployments/k8s/03-functions/Makefile
@@ -1,0 +1,22 @@
+.PHONY: configmap image service
+
+image:
+	export $(shell minikube docker-env)
+	docker build . -t functions
+
+service: 
+	kubectl create -n statefun -f functions-service.yaml
+
+upgrade:
+	kubectl rollout restart deployment/functions
+
+logs:
+	kubectl logs -f -l component=functions -n statefun
+
+pods:
+	kubectl get pods -n statefun -l component=functions
+
+delete:
+	kubectl delete deployment functions -n statefun
+	kubectl delete svc functions -n statefun
+

--- a/deployments/k8s/03-functions/functions-service.yaml
+++ b/deployments/k8s/03-functions/functions-service.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: functions 
+  namespace: statefun
+spec:
+  type: ClusterIP
+  ports:
+    - name: endpoint
+      port: 8000
+  selector:
+    app: statefun
+    component: functions 
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: functions
+  namespace: statefun
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: statefun
+      component: functions 
+  template:
+    metadata:
+      labels:
+        app: statefun
+        component: functions 
+    spec:
+      containers:
+        - name: functions 
+          image: functions 
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: endpoint
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 60
+

--- a/deployments/k8s/03-functions/functions.py
+++ b/deployments/k8s/03-functions/functions.py
@@ -1,0 +1,46 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import json
+
+from statefun import *
+import asyncio
+from aiohttp import web
+
+functions = StatefulFunctions()
+
+
+@functions.bind(typename="example/hello")
+async def hello(context: Context, message: Message):
+    arg = message.raw_value().decode('utf-8')
+    print(f"Hello from {context.address.id}: you wrote {arg}!", flush=True)
+   
+
+
+handler = RequestReplyHandler(functions)
+
+async def handle(request):
+    req = await request.read()
+    res = await handler.handle_async(req)
+    return web.Response(body=res, content_type="application/octet-stream")
+
+
+app = web.Application()
+app.add_routes([web.post('/statefun', handle)])
+
+if __name__ == '__main__':
+    web.run_app(app, port=8000)

--- a/deployments/k8s/03-functions/requirements.txt
+++ b/deployments/k8s/03-functions/requirements.txt
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+aiohttp
+apache-flink-statefun

--- a/deployments/k8s/04-statefun/00-module.yaml
+++ b/deployments/k8s/04-statefun/00-module.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: statefun
+  name: module-config
+data:
+  module.yaml: |+
+    version: "3.0"
+    module:
+      meta:
+        type: remote
+      spec:
+        endpoints:
+          - endpoint:
+              meta:
+                kind: http
+              spec:
+                functions: example/*
+                urlPathTemplate: http://functions.statefun.svc.cluster.local:8000/statefun
+                timeouts:
+                  call: 2min
+        ingresses:
+          - ingress:
+              meta:
+                type: io.statefun.kafka/ingress
+                id: example/in
+              spec:
+                address: kafka.statefun.svc.cluster.local:9092
+                consumerGroupId: my-group-id
+                topics:
+                  - topic: names
+                    valueType: example/MyMessage
+                    targets:
+                      - example/hello
+

--- a/deployments/k8s/04-statefun/01-statefun-runtime.yaml
+++ b/deployments/k8s/04-statefun/01-statefun-runtime.yaml
@@ -1,0 +1,202 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: statefun
+  name: flink-config
+  labels:
+    app: statefun
+data:
+  flink-conf.yaml: |+
+    jobmanager.rpc.address: statefun-master
+    taskmanager.numberOfTaskSlots: 1
+    blob.server.port: 6124
+    jobmanager.rpc.port: 6123
+    taskmanager.rpc.port: 6122
+    classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
+    state.backend: rocksdb
+    state.backend.rocksdb.timer-service.factory: ROCKSDB
+    state.backend.incremental: true
+    parallelism.default: 1 
+    s3.access-key: minioadmin
+    s3.secret-key: minioadmin
+    state.checkpoints.dir: s3://checkpoints/subscriptions
+    s3.endpoint: http://minio.statefun.svc.cluster.local:9000
+    s3.path-style-access: true
+    jobmanager.memory.process.size: 1g 
+    taskmanager.memory.process.size: 1g
+    
+  log4j-console.properties: |+
+          monitorInterval=30
+          rootLogger.level = INFO
+          rootLogger.appenderRef.console.ref = ConsoleAppender
+          logger.akka.name = akka
+          logger.akka.level = INFO
+          logger.kafka.name= org.apache.kafka
+          logger.kafka.level = INFO
+          logger.hadoop.name = org.apache.hadoop
+          logger.hadoop.level = INFO
+          logger.zookeeper.name = org.apache.zookeeper
+          logger.zookeeper.level = INFO
+          appender.console.name = ConsoleAppender
+          appender.console.type = CONSOLE
+          appender.console.layout.type = PatternLayout
+          appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+          logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+          logger.netty.level = OFF 
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: statefun-master-rest
+  namespace: statefun
+spec:
+  type: NodePort
+  ports:
+    - name: rest
+      port: 8081
+      targetPort: 8081
+  selector:
+    app: statefun
+    component: master
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: statefun-master
+  namespace: statefun
+spec:
+  type: ClusterIP
+  ports:
+    - name: rpc
+      port: 6123
+    - name: blob
+      port: 6124
+    - name: ui
+      port: 8081
+  selector:
+    app: statefun
+    component: master
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: statefun-master
+  namespace: statefun
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: statefun
+      component: master
+  template:
+    metadata:
+      labels:
+        app: statefun
+        component: master
+    spec:
+      containers:
+        - name: master
+          image: apache/flink-statefun:3.0.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ROLE
+              value: master
+            - name: MASTER_HOST
+              value: statefun-master
+          ports:
+            - containerPort: 6123
+              name: rpc
+            - containerPort: 6124
+              name: blob
+            - containerPort: 8081
+              name: ui
+          livenessProbe:
+            tcpSocket:
+              port: 6123
+            initialDelaySeconds: 30
+            periodSeconds: 60
+          volumeMounts:
+            - name: flink-config-volume
+              mountPath: /opt/flink/conf
+            - name: module-config-volume
+              mountPath: /opt/statefun/modules/example
+      volumes:
+        - name: flink-config-volume
+          configMap:
+            name: flink-config
+            items:
+              - key: flink-conf.yaml
+                path: flink-conf.yaml
+              - key: log4j-console.properties
+                path: log4j-console.properties
+        - name: module-config-volume
+          configMap:
+            name: module-config
+            items:
+              - key: module.yaml
+                path: module.yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: statefun-worker
+  namespace: statefun
+spec:
+  replicas: 1 
+  selector:
+    matchLabels:
+      app: statefun
+      component: worker
+  template:
+    metadata:
+      labels:
+        app: statefun
+        component: worker
+    spec:
+      containers:
+        - name: worker
+          image: apache/flink-statefun:3.0.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ROLE
+              value: worker
+            - name: MASTER_HOST
+              value: statefun-master 
+          resources:
+            requests:
+              memory: "1Gi"
+          ports:
+            - containerPort: 6122
+              name: rpc
+            - containerPort: 6124
+              name: blob
+            - containerPort: 8081
+              name: ui
+          livenessProbe:
+            tcpSocket:
+              port: 6122
+            initialDelaySeconds: 30
+            periodSeconds: 60
+          volumeMounts:
+            - name: flink-config-volume
+              mountPath: /opt/flink/conf
+            - name: module-config-volume
+              mountPath: /opt/statefun/modules/example
+      volumes:
+        - name: flink-config-volume
+          configMap:
+            name: flink-config
+            items:
+              - key: flink-conf.yaml
+                path: flink-conf.yaml
+              - key: log4j-console.properties
+                path: log4j-console.properties
+        - name: module-config-volume
+          configMap:
+            name: module-config
+            items:
+              - key: module.yaml
+                path: module.yaml
+

--- a/deployments/k8s/README.md
+++ b/deployments/k8s/README.md
@@ -1,0 +1,108 @@
+# Kubernetes Example
+
+## Background
+
+This example demonstrates deploying `Apache Flink StateFun`, together with a single [remote function](03-functions/functions.py) to `kubernetes`.
+
+All the components are already pre-configured and contains all the resource definitions ready to be applied with `kubectl`.
+All the resources are deployed to a dedicated namespace - `statefun`.
+
+## What's inside?
+
+The following components will be installed:
+
+1. Apache Kafka
+2. MinIO (S3 compatible object store)
+3. A StateFun service [functions.py](03-functions/functions.py)
+4. Apache Flink Cluster that executes a StateFun Job.  Take a look at [module.yaml](04-statefun/00-module.yaml) config-map. 
+	The resources defined at [statefun-runtime.yaml](04-statefun/ 01-statefun-runtime.yaml) are already pre-configured for that specific example.
+
+## Prerequisites
+
+
+```
+minikube config set memory 5120
+minikube start
+minikube ssh 'sudo ip link set docker0 promisc on'
+eval $(minikube -p minikube docker-env)
+```
+
+## Create the `statefun` namespace.
+
+```
+kubectl create -f 00-namespace
+kubectl config set-context --current --namespace statefun
+```
+
+## Create auxiliary services that are need for this example:
+ 
+```
+kubectl create -f 01-minio
+kubectl create -f 02-kafka
+```
+
+## Create the function:
+
+**NOTE:**  please make sure that you've run `eval $(minikube -p minikube docker-env)` In your current terminal session.
+
+```
+cd 03-functions
+make image
+make service
+cd ..
+```
+
+## Start the StateFun runtime
+
+```
+kubectl create -f 04-statefun
+```
+
+## Open the Flink's WEB UI
+
+```
+ kubectl port-forward svc/statefun-master-rest 8081:8081 -n statefun
+```
+
+Now you can explore Apache Flink's WEB interface:
+
+[http://localhost:8081/#/overview](http://localhost:8081/#/overview)
+
+## Interact with the Function!
+
+In one terminal run:
+```
+bin/show-function-logs.sh
+```
+
+And in another run:
+
+```
+bin/invoke-function.sh
+```
+
+When prompted with:
+```
+Please enter a target id:
+```
+
+try writing your name.
+
+```
+Please enter a message:
+```
+
+Write any message you would like.
+
+In the previous console you will see:
+`Hello from <name>: you wrote  <message>!`
+
+## Teardown
+
+```
+kubectl delete namespace statefun
+minikube stop
+```
+
+
+

--- a/deployments/k8s/bin/invoke-function.sh
+++ b/deployments/k8s/bin/invoke-function.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+POD="$(kubectl get pods -n statefun -l app=kafka --no-headers=true -o custom-columns=:metadata.name)"
+
+send_to_kafka () {
+    local key=$1
+    local payload=$2
+    kubectl exec -n statefun -it ${POD} -- bash -c "unset JMX_PORT && unset KAFKA_JMX_OPTS && echo '$key: $payload' | kafka-console-producer.sh --topic names --broker-list localhost:9092 --property 'parse.key=true' --property 'key.separator=:'"
+}
+
+if [ -z "$POD" ]; then
+	echo "Unable to find a Kafka broker. Did you run: kubectl create -f kafka.yaml ?"
+	exit 1
+fi
+
+echo "Kafka POD found at ${POD}"
+echo "hit CTRL+C to exit ..."
+
+while [ 1 ]; do
+	echo "Please enter a target id:"
+	read key
+	if [ -z "$key" ]; then
+		echo "target must be provided."
+		continue
+	fi
+
+	echo "Please enter a message"
+	read value
+	send_to_kafka "$key" "$value" &> /dev/null
+done

--- a/deployments/k8s/bin/show-function-logs.sh
+++ b/deployments/k8s/bin/show-function-logs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kubectl logs -f -l component=functions -n statefun


### PR DESCRIPTION
This PR adds an already pre-configured, ready to `kubectl apply` k8s example.

copied from README.md:
---------------------------

# Kubernetes Example

## Background

This example demonstrates deploying `Apache Flink StateFun`, together with a single [remote function](03-functions/functions.py) to `kubernetes`.

All the components are already pre-configured and contains all the resource definitions ready to be applied with `kubectl`.
All the resources are deployed to a dedicated namespace - `statefun`.

## What's inside?

The following components will be installed:

1. Apache Kafka
2. MinIO (S3 compatible object store)
3. A StateFun service [functions.py](03-functions/functions.py)
4. Apache Flink Cluster that executes a StateFun Job.  Take a look at [module.yaml](04-statefun/00-module.yaml) config-map. 
	The resources defined at [statefun-runtime.yaml](04-statefun/ 01-statefun-runtime.yaml) are already pre-configured for that specific example.

## Prerequisites


```
minikube config set memory 5120
minikube start
minikube ssh 'sudo ip link set docker0 promisc on'
eval $(minikube -p minikube docker-env)
```

## Create the `statefun` namespace.

```
kubectl create -f 00-namespace
kubectl config set-context --current --namespace statefun
```

## Create auxiliary services that are need for this example:
 
```
kubectl create -f 01-minio
kubectl create -f 02-kafka
```

## Create the function:

**NOTE:**  please make sure that you've run `eval $(minikube -p minikube docker-env)` In your current terminal session.

```
cd 03-functions
make image
make service
cd ..
```

## Start the StateFun runtime

```
kubectl create -f 04-statefun
```

## Open the Flink's WEB UI

```
 kubectl port-forward svc/statefun-master-rest 8081:8081 -n statefun
```

Now you can explore Apache Flink's WEB interface:

[http://localhost:8081/#/overview](http://localhost:8081/#/overview)

## Interact with the Function!

In one terminal run:
```
bin/show-function-logs.sh
```

And in another run:

```
bin/invoke-function.sh
```

When prompted with:
```
Please enter a target id:
```

try writing your name.

```
Please enter a message:
```

Write any message you would like.

In the previous console you will see:
`Hello from <name>: you wrote  <message>!`

## Teardown

```
kubectl delete namespace statefun
minikube stop
```


