### PR TITLE
Fix the Kubernetes example

### DIFF
--- a/deployments/k8s/04-statefun/00-module.yaml
+++ b/deployments/k8s/04-statefun/00-module.yaml
@@ -10,7 +10,6 @@ data:
       functions: example/*
       urlPathTemplate: http://functions.statefun.svc.cluster.local:8000/statefun
       transport:
-        type: io.statefun.transports.v1/okhttp
         timeouts:
           call: 2min
     ---

--- a/deployments/k8s/04-statefun/00-module.yaml
+++ b/deployments/k8s/04-statefun/00-module.yaml
@@ -5,7 +5,7 @@ metadata:
   name: module-config
 data:
   module.yaml: |+
-    kind: io.statefun.endpoints.v2.http
+    kind: io.statefun.endpoints.v2/http
     spec:
       functions: example/*
       urlPathTemplate: http://functions.statefun.svc.cluster.local:8000/statefun
@@ -18,9 +18,9 @@ data:
       id: example/in
       address: kafka.statefun.svc.cluster.local:9092
       consumerGroupId: my-group-id
-        topics:
-          - topic: names
-            valueType: example/MyMessage
-            targets:
-              - example/hello
+      topics:
+        - topic: names
+          valueType: example/MyMessage
+          targets:
+            - example/hello
 

--- a/deployments/k8s/04-statefun/00-module.yaml
+++ b/deployments/k8s/04-statefun/00-module.yaml
@@ -10,6 +10,7 @@ data:
       functions: example/*
       urlPathTemplate: http://functions.statefun.svc.cluster.local:8000/statefun
       transport:
+        type: io.statefun.transports.v1/okhttp
         timeouts:
           call: 2min
     ---

--- a/deployments/k8s/04-statefun/01-statefun-runtime.yaml
+++ b/deployments/k8s/04-statefun/01-statefun-runtime.yaml
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
         - name: master
-          image: apache/flink-statefun:3.1.0
+          image: apache/flink-statefun:3.2.0
           imagePullPolicy: IfNotPresent
           env:
             - name: ROLE
@@ -157,7 +157,7 @@ spec:
     spec:
       containers:
         - name: worker
-          image: apache/flink-statefun:3.1.0
+          image: apache/flink-statefun:3.2.0
           imagePullPolicy: IfNotPresent
           env:
             - name: ROLE


### PR DESCRIPTION
Some minor typos and a mysteriously missing `type:` for `transport:` were preventing the Kubernetes example from working. According to the documentation at https://nightlies.apache.org/flink/flink-statefun-docs-master/docs/modules/http-endpoint/#transport:
>  If not specified, by default, Stateful Functions uses OkHttp.

But instead it was throwing: `MissingKeyException: missing key /type`. By explicitly adding the `type:` value, it no longer throws the exception.