### PR TITLE
apache/flink-statefun-playground:3.3.0 stil doesn't exist on docker hub

### DIFF
--- a/javascript/showcase/docker-compose.yml
+++ b/javascript/showcase/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   ###############################################################
 
   statefun:
-    image: apache/flink-statefun-playground:3.3.0
+    image: apache/flink-statefun-playground:3.2.0-1.0
     ports:
       - "8081:8081"
     depends_on:


### PR DESCRIPTION
last published versions is 

apache/flink-statefun-playground:3.2.0-1.0

https://hub.docker.com/r/apache/flink-statefun-playground/tags